### PR TITLE
Do not operate on empty data

### DIFF
--- a/src/DoctrineEncrypt/Encryptors/AES256Encryptor.php
+++ b/src/DoctrineEncrypt/Encryptors/AES256Encryptor.php
@@ -31,6 +31,10 @@ class AES256Encryptor implements EncryptorInterface
      */
     public function encrypt($data)
     {
+        if (!is_string($data) || empty($data)) {
+            return $data;
+        }
+
         return trim(
             base64_encode(
                 mcrypt_encrypt(
@@ -51,6 +55,9 @@ class AES256Encryptor implements EncryptorInterface
      */
     public function decrypt($data) 
     {
+        if (!is_string($data) || empty($data)) {
+            return $data;
+        }
         return trim(
             mcrypt_decrypt(
                 MCRYPT_RIJNDAEL_256,


### PR DESCRIPTION
Not checking for empty/null values can cause issues especially when decrypting a field with null values.
